### PR TITLE
mysql binlog names can contain numbers

### DIFF
--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
@@ -73,7 +73,7 @@ import com.linkedin.databus2.schemas.SchemaRegistryService;
 public class OpenReplicatorEventProducer extends AbstractEventProducer
 {
   public static final Integer DEFAULT_MYSQL_PORT = 3306;
-  public static final Pattern PATH_PATTERN = Pattern.compile("/([0-9]+)/[a-z|A-Z|-]+");
+  public static final Pattern PATH_PATTERN = Pattern.compile("/([0-9]+)/[0-9a-zA-Z-]+");
 
   protected final Logger _log;
   private final OpenReplicator _or;
@@ -181,7 +181,7 @@ public class OpenReplicatorEventProducer extends AbstractEventProducer
    * @return Bin Log Prefix
    * @throws InvalidConfigException if URI is incorrect or missing information
    */
-  static protected String processUri(URI uri, OpenReplicator or) throws InvalidConfigException
+  public static String processUri(URI uri, OpenReplicator or) throws InvalidConfigException
   {
     String userInfo = uri.getUserInfo();
     if (null == userInfo)

--- a/databus2-relay/databus2-event-producer-or/src/test/java/com/linkedin/databus2/producers/TestOpenReplicatorEventProducer.java
+++ b/databus2-relay/databus2-event-producer-or/src/test/java/com/linkedin/databus2/producers/TestOpenReplicatorEventProducer.java
@@ -1,0 +1,30 @@
+package com.linkedin.databus2.producers;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+import com.google.code.or.OpenReplicator;
+import com.linkedin.databus.core.util.InvalidConfigException;
+
+public class TestOpenReplicatorEventProducer {
+	@Test
+	public void testUriPaths() throws Exception {
+		runUriTest("mysql://user%2Fpassword@localhost:3306/1/mysql-binlog", "user", "password", "localhost", 3306, 1, "mysql-binlog");
+		runUriTest("mysql://user%2Fpassword@localhost:3306/1/mysql5-binlog", "user", "password", "localhost", 3306, 1, "mysql5-binlog");
+	}
+
+	private void runUriTest(String raw, String user, String password, String host, int port, int serverId, String filename) throws InvalidConfigException, URISyntaxException {
+		OpenReplicator or = new OpenReplicator();
+		String prefix = OpenReplicatorEventProducer.processUri(new URI(raw), or);
+		assertEquals(or.getUser(), user);
+		assertEquals(or.getPassword(), password);
+		assertEquals(or.getHost(), host);
+		assertEquals(or.getPort(), port);
+		assertEquals(or.getServerId(), serverId);
+		assertEquals(prefix, filename);
+	}
+}


### PR DESCRIPTION
the base names for mysql binlog files may contain numbers, which OpenReplicatorEventProducer seems to preclude, based on a flawed regex used to parse connection urls.  I've updated the regex and provided a place to add tests for this functionality.
