### PR TITLE
override isRunning and isPaused method to fixbug shutdown open replicator

### DIFF
--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
@@ -510,6 +510,23 @@ public class OpenReplicatorEventProducer extends AbstractEventProducer
     throw new RuntimeException("Not supported !!");
   }
 
+  /* (non-Javadoc)
+   * @see com.linkedin.databus2.producers.AbstractEventProducer#isPaused()
+   */
+  @Override
+  public synchronized boolean isPaused()
+  {
+    return _producerThread.isPauseRequested();
+  }
+
+  /* (non-Javadoc)
+   * @see com.linkedin.databus2.producers.AbstractEventProducer#isRunning()
+   */
+  @Override
+  public synchronized boolean isRunning()
+  {
+    return !_producerThread.isShutdownRequested() && !_producerThread.isPauseRequested();
+  }
 
   /* (non-Javadoc)
    * @see com.linkedin.databus2.producers.AbstractEventProducer#unpause()


### PR DESCRIPTION
override the AbstractEventProducer‘s isRunning and isPaused method to let open replicator stop normally. 
The default isPaused and isRunning methods in AbstractEventProducer couldn't identify the right status of OpenReplicatorEventProducer. So the relay won't stop the open replicator when it shutdown.