### PR TITLE
Upgrade Apache Commons Collection to v3.2.2

### DIFF
--- a/subprojects.gradle
+++ b/subprojects.gradle
@@ -18,7 +18,7 @@ ext.externalDependency = [
     'commonsBeanutils': 'commons-beanutils:commons-beanutils:1.7.0',
     'commonsCli': 'commons-cli:commons-cli:1.2',
     'commonsCodec': 'commons-codec:commons-codec:1.6',
-    'commonsCollections': 'commons-collections:commons-collections:3.2.1',
+    'commonsCollections': 'commons-collections:commons-collections:3.2.2',
     'commonsIo': 'commons-io:commons-io:1.4',
     'commonsLang': 'commons-lang:commons-lang:2.5',
     'commonsLogging': 'commons-logging:commons-logging:1.1',


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/
