### PR TITLE
client can't start when conern too many tables

### DIFF
--- a/databus-client/databus-client-http/src/main/java/com/linkedin/databus/client/netty/GenericHttpResponseHandler.java
+++ b/databus-client/databus-client-http/src/main/java/com/linkedin/databus/client/netty/GenericHttpResponseHandler.java
@@ -361,11 +361,11 @@ public class GenericHttpResponseHandler extends SimpleChannelHandler {
       _log.debug("WriteComplete");
       // Future should be done by this time
       ChannelFuture future = e.getFuture();
-    
+
       boolean success = future.isSuccess();
       if(_httpRequest == null && success){
-  	    super.writeComplete(ctx, e);
-  	    return;
+        super.writeComplete(ctx, e);
+        return;
       }
       if(! validateCurrentState(e.getChannel(), MessageState.REQUEST_START)) {
         _httpRequest = null;

--- a/databus-client/databus-client-http/src/main/java/com/linkedin/databus/client/netty/GenericHttpResponseHandler.java
+++ b/databus-client/databus-client-http/src/main/java/com/linkedin/databus/client/netty/GenericHttpResponseHandler.java
@@ -356,21 +356,22 @@ public class GenericHttpResponseHandler extends SimpleChannelHandler {
                                          WriteCompletionEvent e) throws Exception {
 
     Throwable cause = null;
-    if(_httpRequest == null)
-      super.writeComplete(ctx, e);
 
     synchronized(this) {
       _log.debug("WriteComplete");
-
+      // Future should be done by this time
+      ChannelFuture future = e.getFuture();
+    
+      boolean success = future.isSuccess();
+      if(_httpRequest == null && success){
+  	    super.writeComplete(ctx, e);
+  	    return;
+      }
       if(! validateCurrentState(e.getChannel(), MessageState.REQUEST_START)) {
         _httpRequest = null;
         return;
       }
 
-      // Future should be done by this time
-      ChannelFuture future = e.getFuture();
-
-      boolean success = future.isSuccess();
       if (!success) {
         String msg = "Write request failed with cause :" + future.getCause();
         _log.error(msg);


### PR DESCRIPTION
In cluster mode, if we concern a lot of tables ( e.g more than 180 ), then client application can't start right. After some tests , we found that , the request is too long and the writeComplete function is invoked multi times , part of exception stack is here and the code has been run in our system for months:
java.lang.IllegalStateException: unexpected state: expectedState=REQUEST_START; actual StateRESPONSE_START
at com.linkedin.databus.client.netty.GenericHttpResponseHandler.validateCurrentState(GenericHttpResponseHandler.java:180)
at com.linkedin.databus.client.netty.GenericHttpResponseHandler.writeComplete(GenericHttpResponseHandler.java:374)
at org.jboss.netty.channel.SimpleChannelHandler.handleUpstream(SimpleChannelHandler.java:91)
at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
at org.jboss.netty.channel.DefaultChannelPipeline$DefaultChannelHandlerContext.sendUpstream(DefaultChannelPipeline.java:791)
at org.jboss.netty.channel.SimpleChannelUpstreamHandler.writeComplete(SimpleChannelUpstreamHandler.java:233)
at org.jboss.netty.channel.SimpleChannelUpstreamHandler.handleUpstream(SimpleChannelUpstreamHandler.java:73)
at org.jboss.netty.channel.DefaultChannelPipeline.sendUpstream(DefaultChannelPipeline.java:564)
