### PR TITLE
Fix too many end period marker

### DIFF
--- a/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
+++ b/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
@@ -3348,22 +3348,22 @@ DbusEventBufferAppendable, DbusEventBufferStreamAppendable
                 {
                 case OK:
                 {
-				  if (readPos.getCurEvent().isEndOfPeriodMarker())
-				  {
-					if (preEndPeriodEvent)
-					{
-					  readPos.eventSkipped();
-					  break;
-					}
-					else
-					{
-					  preEndPeriodEvent = true;
-					}
-				  }
-				  else
-				  {
-					preEndPeriodEvent = false;
-				  }
+                  if (readPos.getCurEvent().isEndOfPeriodMarker())
+                  {
+                    if (preEndPeriodEvent)
+                    {
+                      readPos.eventSkipped();
+                      break;
+                    }
+                    else
+                    {
+                      preEndPeriodEvent = true;
+                    }
+                  }
+                  else
+                  {
+                    preEndPeriodEvent = false;
+                  }
                   final int curEventSize = readPos.getCurEvent().size();
                   if (readPos.bytesProcessed() + curEventSize > contiguousCapacity)
                   {

--- a/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
+++ b/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
@@ -3331,6 +3331,7 @@ DbusEventBufferAppendable, DbusEventBufferStreamAppendable
 
               readBuffer.flip();
               boolean hasMoreInStgBuffer = true;
+              boolean preEndPeriodEvent = false;
               while (hasMoreInStgBuffer && readPos.hasNext())
               {
                 writePos.startNewIteration();
@@ -3347,6 +3348,22 @@ DbusEventBufferAppendable, DbusEventBufferStreamAppendable
                 {
                 case OK:
                 {
+				  if (readPos.getCurEvent().isEndOfPeriodMarker())
+				  {
+					if (preEndPeriodEvent)
+					{
+					  readPos.eventSkipped();
+					  break;
+					}
+					else
+					{
+					  preEndPeriodEvent = true;
+					}
+				  }
+				  else
+				  {
+					preEndPeriodEvent = false;
+				  }
                   final int curEventSize = readPos.getCurEvent().size();
                   if (readPos.bytesProcessed() + curEventSize > contiguousCapacity)
                   {


### PR DESCRIPTION
There are too many endPeriodMarker events in follow cases:
1、relay has a lot of tables ,and the client do not concern.
2、in cluster mode，too many partitions(e.g more than 18)
When a lot of endPeriodMarker events comes ,zhe Dispatcher thread is holded to handle these events,store checkpoint and remove buffer。Some times,one endPeriodMarker events may cost more than 1 seconds.After this change,zhe relay maybe more common,and supply service for more client.