### PR TITLE
add int unsigned col type support

### DIFF
--- a/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/AvroPrimitiveTypes.java
+++ b/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/AvroPrimitiveTypes.java
@@ -44,7 +44,17 @@ public enum AvroPrimitiveTypes
   BLOB("bytes"),
   ARRAY("array"),
   TABLE("record"),
-  XMLTYPE("string");
+  XMLTYPE("string"),
+  TINYINT("int"),
+  TINYINT_UNSIGNED("int"),
+  SMALLINT("int"),
+  SMALLINT_UNSIGNED("int"),
+  MEDIUMINT("int"),
+  MEDIUMINT_UNSIGNED("int"),
+  INT("int"),
+  INT_UNSIGNED("int"),
+  BIGINT("long"),
+  BIGINT_UNSIGNED("long");
 
   private final String _avroType;
   private AvroPrimitiveTypes(String avroType)

--- a/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/AvroPrimitiveTypes.java
+++ b/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/AvroPrimitiveTypes.java
@@ -28,7 +28,8 @@ package com.linkedin.databus.util;
  */
 public enum AvroPrimitiveTypes
 {
-  INTEGER("int"),
+  INTEGER("long"),
+  INTEGER_UNSIGNED("long"),
   LONG("long"),
   RAW("bytes"),
   FLOAT("float"),
@@ -51,8 +52,8 @@ public enum AvroPrimitiveTypes
   SMALLINT_UNSIGNED("int"),
   MEDIUMINT("int"),
   MEDIUMINT_UNSIGNED("int"),
-  INT("int"),
-  INT_UNSIGNED("int"),
+  INT("long"),
+  INT_UNSIGNED("long"),
   BIGINT("long"),
   BIGINT_UNSIGNED("long");
 

--- a/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/SimpleTypeInfo.java
+++ b/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/SimpleTypeInfo.java
@@ -30,7 +30,28 @@ public class SimpleTypeInfo
 
   public SimpleTypeInfo(String name, int precision, int scale)
   {
-    if(name.equals("NUMBER"))
+    boolean unsigned = false;
+    if (name.contains(" "))
+    {
+      String nameArr[] = name.split(" ");
+      if (nameArr[1].trim().toLowerCase().equals("unsigned"))
+      {
+        unsigned = true;
+      }
+      name = nameArr[0];
+    }
+    if (name.toLowerCase().equals("integer") || name.toLowerCase().endsWith("int"))
+    {
+      if ((precision > 9) || (precision == 0))
+      {
+        _type = unsigned ? AvroPrimitiveTypes.BIGINT_UNSIGNED : AvroPrimitiveTypes.BIGINT;
+      }
+      else
+      {
+        _type = AvroPrimitiveTypes.valueOf((name + (unsigned ? "_unsigned" : "")).toUpperCase());
+      }
+    }
+    else if(name.equals("NUMBER"))
     {
       if(scale > 0)
       {


### PR DESCRIPTION
   Mysql col type contains int、tinyInt、mediumInt、bigInt。Dbus do not support these types。When we put these types with "int" in 'AvroPrimitiveTypes', If this types is set to unsigned，the value may be not right。For example,tinyInt unsigned( popular used in our system),192 in mysql,but we get -64. we do some changes to make it support int column Type.