### PR TITLE
Fix : updating correct scn at the end of transaction from ignored source

### DIFF
--- a/databus2-relay/databus2-event-producer-common/src/main/java/com/linkedin/databus2/producers/ds/Transaction.java
+++ b/databus2-relay/databus2-event-producer-common/src/main/java/com/linkedin/databus2/producers/ds/Transaction.java
@@ -50,6 +50,18 @@ public class Transaction
 	 */
 	private long _txnNanoTimestamp;
 
+	private long ignoredSourceScn = -1;
+
+
+	public long getIgnoredSourceScn() {
+		return ignoredSourceScn;
+	}
+
+	public void setIgnoredSourceScn(long ignoredSourceScn) {
+		this.ignoredSourceScn = ignoredSourceScn;
+	}
+
+
 	public Transaction()
 	{
 		_perSourceTxnEntries = new HashMap<Integer,PerSourceTransaction>();

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
@@ -226,6 +226,12 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
     _transaction.setSizeInBytes(_currTxnSizeInBytes);
     _transaction.setTxnNanoTimestamp(_currTxnTimestamp);
     _transaction.setTxnReadLatencyNanos(txnReadLatency);
+
+    if(_ignoreSource) {
+      long scn = scn(_currFileNum, (int)e.getHeader().getPosition());
+      _transaction.setIgnoredSourceScn(scn);
+    }
+
     try
     {
       _txnProcessor.onEndTransaction(_transaction);

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
@@ -478,7 +478,7 @@ public class OpenReplicatorEventProducer extends AbstractEventProducer
       try
       {
         addTxnToBuffer(txn);
-        _maxSCNReaderWriter.saveMaxScn(txn.getScn());
+        _maxSCNReaderWriter.saveMaxScn(txn.getIgnoredSourceScn()!=-1 ? txn.getIgnoredSourceScn() : txn.getScn());
       }
       catch (UnsupportedKeyException e)
       {


### PR DESCRIPTION
If source is ignored, then scn of transaction will be -1. Scn is persisted as -1 after processing transaction from ignored source. In this case, if relay restart it will start with scn as -1.