### PR TITLE
Refactor or to avro type function

### DIFF
--- a/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/FieldToAvro.java
+++ b/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/FieldToAvro.java
@@ -202,7 +202,7 @@ public class FieldToAvro
     field.put("default", null);
 
     // Field type
-    String[] type = new String[] { typeInfo.getPrimitiveType().getAvroType(), "null"};
+    String[] type = new String[] {"null", typeInfo.getPrimitiveType().getAvroType()};
     field.put("type", type);
 
     // Field metadata

--- a/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/FieldToAvro.java
+++ b/databus-util-cmdline/databus-util-cmdline-impl/src/main/java/com/linkedin/databus/util/FieldToAvro.java
@@ -202,7 +202,7 @@ public class FieldToAvro
     field.put("default", null);
 
     // Field type
-    String[] type = new String[] { "null", typeInfo.getPrimitiveType().getAvroType() };
+    String[] type = new String[] { typeInfo.getPrimitiveType().getAvroType(), "null"};
     field.put("type", type);
 
     // Field metadata

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
@@ -565,7 +565,7 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
 	{
 		if (!(s.getValue() instanceof byte[]))
 		{
-			throw new DatabusException("某字段被配置为bytes，但实际不能转换为bytes");
+			throw new DatabusException(avroField.name()+" need convert to bytes,but the column type is " + s.getClass());
 		}
 		byte[] byteArr = (byte[]) s.getValue();
 		return ByteBuffer.wrap(byteArr);

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
@@ -517,61 +517,6 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
     }
     return;
   }
-  
-  private long unsignedOffset(Column s, Field avroField)
-  {
-    if (s instanceof Int24Column)
-    {
-      Int24Column ic = (Int24Column) s;
-      Integer i = ic.getValue();
-      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
-      {
-        return ORListener.MEDIUMINT_MAX_VALUE;
-      }
-      return 0;
-    }
-    else if (s instanceof LongColumn)
-    {
-      LongColumn lc = (LongColumn) s;
-      Long i = lc.getValue().longValue();
-      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
-      {
-        return ORListener.INTEGER_MAX_VALUE;
-      }
-      return 0;
-    }
-    else if (s instanceof LongLongColumn)
-    {
-      LongLongColumn llc = (LongLongColumn) s;
-      Long l = llc.getValue();
-      if (l < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
-      {
-        return ORListener.BIGINT_MAX_VALUE.longValue();
-      }
-      return 0;
-    }
-    else if (s instanceof ShortColumn)
-    {
-      ShortColumn sc = (ShortColumn) s;
-      Integer i = sc.getValue();
-      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
-      {
-        return ORListener.SMALLINT_MAX_VALUE;
-      }
-      return 0;
-    }
-    else if (s instanceof TinyColumn)
-    {
-      TinyColumn tc = (TinyColumn) s;
-      Integer i = tc.getValue();
-      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
-      {
-        return ORListener.TINYINT_MAX_VALUE;
-      }
-      return 0;
-    }
-    return 0;
-  }
 
   /**
    * Given a OR Column, it returns a corresponding Java object that can be inserted into
@@ -633,6 +578,61 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
     {
       throw new DatabusRuntimeException("Unknown schema type " + fieldTypeSchemaStr + " Object = " + s);
     }
+  }
+  
+  private long unsignedOffset(Column s, Field avroField)
+  {
+    if (s instanceof Int24Column)
+    {
+      Int24Column ic = (Int24Column) s;
+      Integer i = ic.getValue();
+      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
+      {
+        return ORListener.MEDIUMINT_MAX_VALUE;
+      }
+      return 0;
+    }
+    else if (s instanceof LongColumn)
+    {
+      LongColumn lc = (LongColumn) s;
+      Long i = lc.getValue().longValue();
+      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
+      {
+        return ORListener.INTEGER_MAX_VALUE;
+      }
+      return 0;
+    }
+    else if (s instanceof LongLongColumn)
+    {
+      LongLongColumn llc = (LongLongColumn) s;
+      Long l = llc.getValue();
+      if (l < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
+      {
+        return ORListener.BIGINT_MAX_VALUE.longValue();
+      }
+      return 0;
+    }
+    else if (s instanceof ShortColumn)
+    {
+      ShortColumn sc = (ShortColumn) s;
+      Integer i = sc.getValue();
+      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
+      {
+        return ORListener.SMALLINT_MAX_VALUE;
+      }
+      return 0;
+    }
+    else if (s instanceof TinyColumn)
+    {
+      TinyColumn tc = (TinyColumn) s;
+      Integer i = tc.getValue();
+      if (i < 0 && SchemaHelper.getMetaField(avroField, "dbFieldType").contains("UNSIGNED"))
+      {
+        return ORListener.TINYINT_MAX_VALUE;
+      }
+      return 0;
+    }
+    return 0;
   }
 
   /**


### PR DESCRIPTION
In some cases, the avro serialization process throw exception for type confused. I thind the root of the problem is that, we make a hard conversion from or type to avro type.That is right but not safe in prod environment. So we change the conversion and make it base on avro schema. Our prod env don't throw that exception again.
By the way , I check the code in open-replicator code about TimeColumn. we found the 1.0.7 version don't have the problem in dbus note.The open-replicator code like this:
"
    	public static java.sql.Time toTime(int value) {
		final int s = (int)(value % 100); value /= 100;
		final int m = (int)(value % 100);
		final int h = (int)(value / 100);
		final Calendar c = Calendar.getInstance();
        c.set(1970, 0, 1, h, m, s);
        c.set(Calendar.MILLISECOND, 0);
        return new java.sql.Time(c.getTimeInMillis());
	}
"