### PR TITLE
client fetch schema with compress

### DIFF
--- a/databus-core/databus-core-container/src/main/java/com/linkedin/databus2/core/container/DatabusHttpHeaders.java
+++ b/databus-core/databus-core-container/src/main/java/com/linkedin/databus2/core/container/DatabusHttpHeaders.java
@@ -51,6 +51,7 @@ public class DatabusHttpHeaders
 
   /** protocol version param name for /register request */
   public static final String PROTOCOL_VERSION_PARAM = "protocolVersion";
+  public static final String PROTOCOL_COMPRESS_PARAM = "compress";
 
   /** max event version - max DbusEvent version client can understand */
   public static final String MAX_EVENT_VERSION = "maxev";

--- a/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/util/CompressUtil.java
+++ b/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/util/CompressUtil.java
@@ -1,0 +1,35 @@
+package com.linkedin.databus.core.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+public class CompressUtil
+{
+  public static String compress(String str) throws IOException
+  {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    GZIPOutputStream gzip = new GZIPOutputStream(out);
+    gzip.write(str.getBytes(Charset.defaultCharset()));
+    gzip.close();
+    String gzipStr = out.toString("ISO-8859-1");
+    return gzipStr;
+  }
+
+  public static String uncompress(String str) throws IOException
+  {
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    ByteArrayInputStream in = new ByteArrayInputStream(str.getBytes("ISO-8859-1"));
+    GZIPInputStream gunzip = new GZIPInputStream(in);
+    byte[] buffer = new byte[256];
+    int n;
+    while ((n = gunzip.read(buffer)) >= 0)
+    {
+      out.write(buffer, 0, n);
+    }
+    return out.toString(Charset.defaultCharset().name());
+  }
+}

--- a/databus2-relay/databus2-relay-impl/src/main/java/com/linkedin/databus/container/request/RegisterRequestProcessor.java
+++ b/databus2-relay/databus2-relay-impl/src/main/java/com/linkedin/databus/container/request/RegisterRequestProcessor.java
@@ -33,6 +33,7 @@ import org.apache.log4j.Logger;
 import org.codehaus.jackson.map.ObjectMapper;
 import com.linkedin.databus.container.netty.HttpRelay;
 import com.linkedin.databus.core.data_model.LogicalSource;
+import com.linkedin.databus.core.util.CompressUtil;
 import com.linkedin.databus2.core.DatabusException;
 import com.linkedin.databus2.core.container.ChunkedWritableByteChannel;
 import com.linkedin.databus2.core.container.DatabusHttpHeaders;
@@ -191,9 +192,15 @@ public class RegisterRequestProcessor implements RequestProcessor
       {
         mapper.writeValue(out, registeredSources);
       }
+      String outStr = out.toString();
+      String compress = request.getParams().getProperty(DatabusHttpHeaders.PROTOCOL_COMPRESS_PARAM);
+      if ("true".equals(compress))
+      {
+        outStr = CompressUtil.compress(outStr);
+      }
 
       ChunkedWritableByteChannel responseContent = request.getResponseContent();
-      byte[] resultBytes = out.toString().getBytes(Charset.defaultCharset());
+      byte[] resultBytes = outStr.getBytes(Charset.defaultCharset());
       responseContent.addMetadata(DatabusHttpHeaders.DBUS_CLIENT_RELAY_PROTOCOL_VERSION_HDR,
                                   registerResponseProtocolVersion);
       responseContent.write(ByteBuffer.wrap(resultBytes));


### PR DESCRIPTION
when we watch more than 2k tables , the schema is so long that the buffered chunk is not enough. we can increase the config and create more chunk,but we think compress the interactive content may be better.
     In this branch, we add the param "compress" to the http request, that make relay and client with different versions work compatible.