### PR TITLE
lift relay pull performance

### DIFF
--- a/databus-core/databus-core-schemas/src/main/java/com/linkedin/databus2/schemas/utils/SchemaHelper.java
+++ b/databus-core/databus-core-schemas/src/main/java/com/linkedin/databus2/schemas/utils/SchemaHelper.java
@@ -219,7 +219,7 @@ public class SchemaHelper
     return Utils.md5(schema.getBytes(Charset.defaultCharset()));
   }
   
-  private static Map<String,List<Field>> orderedMap=new ConcurrentHashMap<String, List<Field>>();
+  private static Map<String,List<Field>> orderedMap = new ConcurrentHashMap<String, List<Field>>();
   /**
    * Order the fields  present in the schema based on the metaFieldName and comparator being passed.
    *

--- a/databus-core/databus-core-schemas/src/main/java/com/linkedin/databus2/schemas/utils/SchemaHelper.java
+++ b/databus-core/databus-core-schemas/src/main/java/com/linkedin/databus2/schemas/utils/SchemaHelper.java
@@ -22,10 +22,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.avro.Schema;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.Schema.Type;
+import org.jboss.netty.util.internal.ConcurrentHashMap;
+
+import com.linkedin.databus2.schemas.VersionedSchema;
 
 
 /**
@@ -213,6 +217,39 @@ public class SchemaHelper
   public static final byte[] getSchemaId(String schema)
   {
     return Utils.md5(schema.getBytes(Charset.defaultCharset()));
+  }
+  
+  private static Map<String,List<Field>> orderedMap=new ConcurrentHashMap<String, List<Field>>();
+  /**
+   * Order the fields  present in the schema based on the metaFieldName and comparator being passed.
+   *
+   * @param schema  Schema containing the fields to be ordered
+   * @param metaFieldName Meta Field for ordering
+   * @param comparator comparator for sorting
+   * @return ordered Field list or null if schema is null
+   */
+  public static List<Field> getOrderedFieldsByDBFieldPosition(final VersionedSchema vs)
+  {
+    if ( null == vs || null == vs.getSchema())
+      return null;
+    List<Field> fieldList = orderedMap.get(vs.getId().toString());
+    if(fieldList != null)
+    {
+    	return fieldList;
+    }
+    
+    Schema schema = vs.getSchema();
+    fieldList = getOrderedFieldsByMetaField(schema, "dbFieldPosition", new Comparator<String>() {
+		@Override
+		public int compare(String o1, String o2) {
+			// TODO Auto-generated method stub
+			int m1 = Integer.parseInt(o1);
+			int m2 = Integer.parseInt(o2);
+			return m1-m2;
+		}
+	});
+    orderedMap.put(vs.getId().toString(), fieldList);
+    return fieldList;
   }
 
   /**

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
@@ -377,7 +377,7 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
       {
         List<Column> cl = r.getColumns();
         GenericRecord gr = new GenericData.Record(schema);
-        generateAvroEvent(schema, cl, gr);
+        generateAvroEvent(vs, cl, gr);
 
         List<KeyPair> kps = generateKeyPair(cl, schema);
 
@@ -426,21 +426,11 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
     return kpl;
   }
 
-  private void generateAvroEvent(Schema schema, List<Column> cols, GenericRecord record)
+  private void generateAvroEvent(VersionedSchema vs, List<Column> cols, GenericRecord record)
       throws DatabusException
   {
     // Get Ordered list of field by dbFieldPosition
-    List<Schema.Field> orderedFields = SchemaHelper.getOrderedFieldsByMetaField(schema, "dbFieldPosition", new Comparator<String>() {
-
-      @Override
-      public int compare(String o1, String o2)
-      {
-        Integer pos1 = Integer.parseInt(o1);
-        Integer pos2 = Integer.parseInt(o2);
-
-        return pos1.compareTo(pos2);
-      }
-    });
+    List<Schema.Field> orderedFields = SchemaHelper.getOrderedFieldsByDBFieldPosition(vs);
 
     // Build Map<AvroFieldType, Columns>
     if (orderedFields.size() != cols.size())


### PR DESCRIPTION
With this branch the relay max qps increase from 2200 to 2500 in our case.
We cache the schema ordered result instead of ordered with every event.