### PR TITLE
cache pk field and get key obj from record

### DIFF
--- a/databus-core/databus-core-schemas/src/main/java/com/linkedin/databus2/schemas/VersionedSchema.java
+++ b/databus-core/databus-core-schemas/src/main/java/com/linkedin/databus2/schemas/VersionedSchema.java
@@ -19,6 +19,9 @@ package com.linkedin.databus2.schemas;
 */
 
 
+import java.util.ArrayList;
+import java.util.List;
+
 import org.apache.avro.Schema;
 
 /**
@@ -30,12 +33,14 @@ public class VersionedSchema
   private final VersionedSchemaId _id;
 
   private final String _origSchemaStr;
+  private final List<Schema.Field> _pkFieldList;
 
   public VersionedSchema(VersionedSchemaId id, Schema s, String origSchemaStr)
   {
     _schema = s;
     _id = id;
     _origSchemaStr = origSchemaStr;
+    _pkFieldList = new ArrayList<Schema.Field>();
   }
 
   public VersionedSchema(String baseName, short id, Schema s, String origSchemaStr)
@@ -84,6 +89,11 @@ public class VersionedSchema
   public VersionedSchemaId getId()
   {
     return _id;
+  }
+  
+  public List<Schema.Field> getPkFieldList()
+  {
+	return _pkFieldList;
   }
 
   /**


### PR DESCRIPTION
in this branch, we make 2 changes.
1. we cache the pk field list in the versioned schema object,for single versioned schema obj,the list is fixed. It's not necessary to calculate it every time.
2. the pk field value is from GenericRecord object, instead of generate value again.

Through this branch, our relay application performance has been improved.
