### PR TITLE
Fix transaction writer thread exit bug

### DIFF
--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
@@ -716,9 +716,13 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
     _log.info("ORListener Thread done");
     doShutdownNotify();
   }
-  
-  public TransactionWriter getTransactionWriter() 
+  @Override
+  public void shutdown()
   {
-	return _transactionWriter;
+    super.shutdown();
+    if (_transactionWriter != null && _transactionWriter.isAlive())
+    {
+      _transactionWriter.shutdown();
+    }
   }
 }

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/ORListener.java
@@ -716,10 +716,13 @@ class ORListener extends DatabusThreadBase implements BinlogEventListener
     _log.info("ORListener Thread done");
     doShutdownNotify();
   }
-  @Override
-  public void shutdown()
+
+  public void shutdownAll()
   {
-    super.shutdown();
+    if(this.isAlive())
+    {
+      this.shutdown();
+    }
     if (_transactionWriter != null && _transactionWriter.isAlive())
     {
       _transactionWriter.shutdown();

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
@@ -413,10 +413,7 @@ public class OpenReplicatorEventProducer extends AbstractEventProducer
           try
           {
             //should stop orListener first to get the final maxScn used for init open replicator.
-            if (_orListener.isAlive())
-            {
-              _orListener.shutdown();
-            }
+            _orListener.shutdownAll();
             long maxScn = _maxSCNReaderWriter.getMaxScn();
             _startPrevScn.set(maxScn);
             initOpenReplicator(maxScn);
@@ -462,10 +459,7 @@ public class OpenReplicatorEventProducer extends AbstractEventProducer
           _log.error("failed to stop Open Replicator", e);
         }
       }
-      if (_orListener.isAlive())
-      {
-        _orListener.shutdown();
-      }
+      _orListener.shutdownAll();
 
       _log.info("Event Producer Thread done");
       doShutdownNotify();

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/OpenReplicatorEventProducer.java
@@ -466,10 +466,6 @@ public class OpenReplicatorEventProducer extends AbstractEventProducer
       {
         _orListener.shutdown();
       }
-      if (_orListener.getTransactionWriter().isAlive())
-      {
-    	_orListener.getTransactionWriter().shutdown();
-      }
 
       _log.info("Event Producer Thread done");
       doShutdownNotify();

--- a/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/TransactionWriter.java
+++ b/databus2-relay/databus2-event-producer-or/src/main/java/com/linkedin/databus2/producers/TransactionWriter.java
@@ -115,6 +115,8 @@ public class TransactionWriter extends DatabusThreadBase
         }
       }
     }
+    log.info("transactionWriter thread done!");
+    doShutdownNotify();
   }
 
 }


### PR DESCRIPTION
when the or thread exit, we found the writer transaction thread can't exit normally.so we add the some code to make thransaction writer thread can exit with the orlistener thread.