### PR TITLE
skip endOfPeriodMarker in stream method

### DIFF
--- a/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
+++ b/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
@@ -2508,6 +2508,10 @@ DbusEventBufferAppendable, DbusEventBufferStreamAppendable
         {
           if (skippedMessages < messagesToSkip)
           {
+            if (e.isEndOfPeriodMarker() || e.isCheckpointMessage())
+            {
+              continue;
+            }
             ++skippedMessages;
             continue;
           }


### PR DESCRIPTION
the windowOffset calculate method is diffrent between relay and client . Client filters the endOfPeriodMarker event as follows:
if (e.isEndOfPeriodMarker())
    { ... }
    else if (e.isCheckpointMessage())
    { ... }
    else // regular dbusEvent
    {
      if (currentWindowScn == e.sequence())
      {
        ++currentWindowOffset;
      }
      else
      {
        currentWindowScn = e.sequence();
        currentWindowOffset = 1L;
      }
    }
but when the client stream events from relay , the filter method like this:
if (state == EventScanningState.FOUND_WINDOW_ZONE)
        {
          if (skippedMessages < messagesToSkip)
          {
            ++skippedMessages;
            continue;
          }
          else
          {
            state = EventScanningState.VALID_ZONE;
          }
        }
}
so when transaction has a lot events and the client's buffer is full.the windowOffset may be not right and the consumer may consume a event twice.