### PR TITLE
fix EOP Error

### DIFF
--- a/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
+++ b/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
@@ -3400,6 +3400,7 @@ DbusEventBufferAppendable, DbusEventBufferStreamAppendable
                       writePos.moveToNextBuffer();
                       _tail.copy(_currentWritePosition);
                       assert assertBuffersLimits();
+                      preEndPeriodEvent = false;
                     }
                   }
                   else


### PR DESCRIPTION
I merge a branch last year for skipping extra EOP event, but I found there may be errors some times.When the buffer need receive a EOP event and the buffer size is not enough, the eop event may be retry next time,but I filter the retry event with local variable preEndPeriodEvent has been set to true. I fix the bug by this branch. 