### PR TITLE
fix relay pull thread fake dead error

### DIFF
--- a/databus-client/databus-client-http/src/main/java/com/linkedin/databus/client/netty/GenericHttpResponseHandler.java
+++ b/databus-client/databus-client-http/src/main/java/com/linkedin/databus/client/netty/GenericHttpResponseHandler.java
@@ -339,8 +339,21 @@ public class GenericHttpResponseHandler extends SimpleChannelHandler {
       {
         _httpRequest = (HttpRequest)e.getMessage();
 
-        if(! validateCurrentState(e.getChannel(), MessageState.REQUEST_WAIT))
-          return;
+		if (!validateCurrentState(e.getChannel(), MessageState.REQUEST_WAIT)) 
+		{
+			if (_messageState != MessageState.CLOSED)
+			{
+				return;
+			}
+			if (_requestListener != null) 
+			{
+				_requestListener.onSendRequestFailure(_httpRequest, new ClosedChannelException());
+			} else
+			{
+				_log.error("this channal has been closed but there is no requestListener!");
+			}
+			return;
+		}
 
         _messageState = MessageState.REQUEST_START;
         if (debugEnabled)


### PR DESCRIPTION
Sometimes The relay puller thread unexpectedly quits. We found that the netty connection may be break before the stream request, so when the relay puller request stream , the request return without any handler.We fix the bug in this branch.