### PR TITLE
Switch Maven-repo URLs to https: scheme (security fix: prevent MITM attacks)

### DIFF
--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -3,10 +3,10 @@ repositories {
   // so we add few open source ones
   mavenCentral()
   maven {
-	url "http://repo.fusesource.com/maven2"
+	url "https://repo.fusesource.com/maven2"
   }
   maven {
-	url "http://maven.restlet.org"
+	url "https://maven.restlet.org"
   }
 
   // local repo for libs we have to ship with     


### PR DESCRIPTION
This issue was reported by a non-LinkedIn employee ("external researcher"), but the internal tracking ticket didn't specify who, so apologies for the lack of credit.