### PR TITLE
fix direct memory leak in partition transition

### DIFF
--- a/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
+++ b/databus-core/databus-core-impl/src/main/java/com/linkedin/databus/core/DbusEventBuffer.java
@@ -69,6 +69,7 @@ import com.linkedin.databus.core.util.RangeBasedReaderWriterLock.LockToken;
 import com.linkedin.databus.core.util.StringUtils;
 import com.linkedin.databus2.core.AssertLevel;
 import com.linkedin.databus2.core.DatabusException;
+import sun.nio.ch.DirectBuffer;
 
 // TODO Decide if we really want to provide a writable iterator to classes outside of DbusEventBuffer.
 public class DbusEventBuffer implements Iterable<DbusEventInternalWritable>,
@@ -1119,6 +1120,18 @@ DbusEventBufferAppendable, DbusEventBufferStreamAppendable
   }
   public synchronized int getRefCount() {
     return _refCount;
+  }
+
+  public void forceReleaseDirectMemory()
+  {
+    clear();
+    for (ByteBuffer buf : _buffers)
+    {
+      if (buf.isDirect())
+      {
+        ((DirectBuffer)buf).cleaner().clean();
+      }
+    }
   }
 
   /**


### PR DESCRIPTION
In our usage, we found there is a direct memory leak issue,  the partition buffer hasn't been reclaimed when datasources when helix drop partitions in client. We use awaiting consumer callback  shutdown and forced direct memory release to avoid this issue.